### PR TITLE
logging instead of print (#37)

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from krakenapi import KrakenApi
@@ -6,6 +7,10 @@ from krakendca.config import Config
 from krakendca.krakendca import KrakenDCA
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s:%(name)s: %(message)s",
+        level=logging.INFO,
+    )
     # Get parameters from configuration file.
     current_directory: str = os.path.dirname(os.path.realpath(__file__))
     config_file: str = current_directory + "/config.yaml"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,27 @@
+import logging
+
+import pytest
+
+
+@pytest.fixture()
+def logging_capture(caplog):
+    """Test fixture that captures logging output at INFO level.
+
+    Filters out any log messages that do not originate from krakendca.
+
+    Use logging_capture.read() in your test to retrieve the current log output.
+    """
+    caplog.set_level(logging.INFO)
+
+    class FilteredLog:
+        def read(self) -> str:
+            return (
+                "\n".join(
+                    record.message
+                    for record in caplog.records
+                    if record.name.startswith("krakendca")
+                )
+                + "\n"
+            )
+
+    return FilteredLog()

--- a/krakendca/krakendca.py
+++ b/krakendca/krakendca.py
@@ -1,4 +1,5 @@
 """Main KrakenDCA object module."""
+import logging
 from typing import Any, Dict, List
 
 from krakenapi import KrakenApi
@@ -6,6 +7,8 @@ from krakenapi import KrakenApi
 from .config import Config
 from .dca import DCA
 from .pair import Pair
+
+logger = logging.getLogger(__name__)
 
 
 class KrakenDCA:
@@ -35,7 +38,7 @@ class KrakenDCA:
         configuration file and data from Kraken.
         :return: None
         """
-        print("Hi, current configuration:")
+        logger.info("Hi, current configuration:")
         asset_pairs: Dict[str, Any] = self.ka.get_asset_pairs()
         for dca_pair in self.config.dca_pairs:
             pair: Pair = Pair.get_pair_from_kraken(
@@ -52,7 +55,7 @@ class KrakenDCA:
                     "ignore_differing_orders", False
                 ),
             )
-            print(dca)
+            logger.info(dca)
             self.dcas_list.append(dca)
 
     def handle_pairs_dca(self) -> None:
@@ -66,7 +69,7 @@ class KrakenDCA:
         if n_dca > 1:
             pair += "s"
 
-        print(f"DCA ({n_dca} {pair}):")
+        logger.info(f"DCA ({n_dca} {pair}):")
         for dca in self.dcas_list:
-            print(dca)
+            logger.info(dca)
             dca.handle_dca_logic()

--- a/tests/test_krakendca.py
+++ b/tests/test_krakendca.py
@@ -1,8 +1,8 @@
 """krakendca.py tests module."""
 import vcr
-from _pytest.capture import CaptureFixture
 from freezegun import freeze_time
 from krakenapi import KrakenApi
+
 from krakendca.config import Config
 from krakendca.dca import DCA
 from krakendca.krakendca import KrakenDCA
@@ -95,25 +95,25 @@ class TestKrakenDCA:
         "tests/fixtures/vcr_cassettes/test_handle_pairs_dca.yaml",
         filter_headers=["API-Key", "API-Sign"],
     )
-    def test_handle_pairs_dca(self, capfd: CaptureFixture) -> None:
+    def test_handle_pairs_dca(self, logging_capture) -> None:
         self.kdca.handle_pairs_dca()
-        captured = capfd.readouterr()
-        assert "buy 0.00519042 ETHEUR @ limit 2882.44" in captured.out
-        assert "buy 0.00051336 XBTEUR @ limit 38857.2" in captured.out
+        captured = logging_capture.read()
+        assert "buy 0.00519042 ETHEUR @ limit 2882.44" in captured
+        assert "buy 0.00051336 XBTEUR @ limit 38857.2" in captured
 
     @freeze_time("2022-03-26 18:37:46")
     @vcr.use_cassette(
         "tests/fixtures/vcr_cassettes/test_handle_pars_dca_max_price.yaml",
         filter_headers=["API-Key", "API-Sign"],
     )
-    def test_handle_pairs_dca_max_price(self, capfd: CaptureFixture) -> None:
+    def test_handle_pairs_dca_max_price(self, logging_capture) -> None:
         self.kdca.dcas_list.pop()
         self.kdca.dcas_list[0].max_price = 0
         self.kdca.handle_pairs_dca()
-        captured = capfd.readouterr()
+        captured = logging_capture.read()
         assert (
             "No DCA for XETHZEUR: Limit price (2797.99) greater "
-            "than maximum price (0)." in captured.out
+            "than maximum price (0)." in captured
         )
 
     @freeze_time("2022-03-26 18:37:46")
@@ -121,11 +121,9 @@ class TestKrakenDCA:
         "tests/fixtures/vcr_cassettes/test_handle_pars_dca_max_price.yaml",
         filter_headers=["API-Key", "API-Sign"],
     )
-    def test_handle_pairs_dca_limit_factor(
-        self, capfd: CaptureFixture
-    ) -> None:
+    def test_handle_pairs_dca_limit_factor(self, logging_capture) -> None:
         self.kdca.dcas_list.pop()
         self.kdca.dcas_list[0].max_price = 0
         self.kdca.handle_pairs_dca()
-        captured = capfd.readouterr()
-        assert "Factor adjusted limit price (0.9850): 2797.99." in captured.out
+        captured = logging_capture.read()
+        assert "Factor adjusted limit price (0.9850): 2797.99." in captured


### PR DESCRIPTION
Replaced all print calls with loggers. 

Some tests that check the log output needed minor adjustments because the `capfd` fixture doesn't properly capture the logging. Also, `vcr` also uses the logging library. Thus, any log messages that do not originate from krakendca must be filtered out (new fixture in `conftest.py`)